### PR TITLE
Fix for multiple flashing window problem

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -166,9 +166,8 @@ fn from_process(process: &str) -> Option<Vec<String>> {
 
     let process_exe = format!("{}.exe", process);
 
-    let lines = stdout.lines().filter(|x| x.contains(&process_exe));
-
-    let lines: Vec<String> = lines
+    let lines = stdout.lines()
+        .filter(|x| x.contains(&process_exe))
         .filter(|x| x.contains("--app-port") && x.contains("--remoting-auth-token"))
         .map(String::from)
         .collect();

--- a/src/client.rs
+++ b/src/client.rs
@@ -183,12 +183,12 @@ fn parse_process(value: &str) -> Result<(String, String)> {
 
     for arg in args {
         if arg.starts_with("--remoting-auth-token") {
-            let val = arg.split("=").collect::<Vec<&str>>()[1];
-            token = Ok(val);
+            let val = arg.split("=").last();
+            token = val.ok_or(Error::AppNotRunning);
         }
         if arg.starts_with("--app-port") {
-            let val = arg.split("=").collect::<Vec<&str>>()[1];
-            port = Ok(val);
+            let val = arg.split("=").last();
+            port = val.ok_or(Error::AppNotRunning);
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -176,23 +176,23 @@ fn from_process(process: &str) -> Option<Vec<String>> {
 }
 
 fn parse_process(value: &str) -> Result<(String, String)> {
-    let re = regex::Regex::new(r#"--remoting-auth-token="?([\w]*)"?.*--app-port="?([0-9]*)"?"#)
-        .or(Err(Error::AppNotRunning))?;
-    let caps = re.captures(value);
-    let caps = caps.ok_or(Error::AppNotRunning)?;
+    let args: Vec<&str> = value.split("\"").collect();
 
-    let token: String = caps
-        .get(1)
-        .ok_or(Error::AppNotRunning)?
-        .as_str()
-        .to_string();
-    let port: String = caps
-        .get(2)
-        .ok_or(Error::AppNotRunning)?
-        .as_str()
-        .to_string();
+    let mut token = Err(Error::AppNotRunning);
+    let mut port = Err(Error::AppNotRunning);
 
-    Ok((token, port))
+    for arg in args {
+        if arg.starts_with("--remoting-auth-token") {
+            let val = arg.split("=").collect::<Vec<&str>>()[1];
+            token = Ok(val);
+        }
+        if arg.starts_with("--app-port") {
+            let val = arg.split("=").collect::<Vec<&str>>()[1];
+            port = Ok(val);
+        }
+    }
+
+    Ok((token?.to_string(), port?.to_string()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hey, I had a small problem while using this crate in my windows gui app. Every time I would try to connect to the client it would flash 2 terminal windows for a second and then close them. 
I tracked the issue down to these 2 Command calls and I changed the first call to not open any new windows and replaced the second call with some rust string operations (I did this before I found the easier solution that I used for the first one). 